### PR TITLE
Small adjustment  to response XML format.

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,8 +43,7 @@ const getItemResult = async (clientId, itemArray) => {
   const responses = await Promise.all(item.responses.map((response) => getResponseResult(clientId, itemId, response.response)));
 
   return {
-    item: {$: {id: itemId}},
-    responses
+    item: {$: {id: itemId}, responses}
   }
 }
 


### PR DESCRIPTION

The output wasn't quite what the portal was expecting.

I copied the following XML from the portal spec test

 ```
    <crater-results>
      <tracking id="12345"/>
      <client id="${client_id}"/>
      <items>
        <item id="${item_id}">
          <responses>
            <response id="${response_id}" score="${score}" concepts="3,6" realNumberScore="2.62039"
              confidenceMeasure="0.34574">
              <advisorylist>
                <advisorycode>101</advisorycode>
              </advisorylist>
            </response>
          </responses>
        </item>
      </items>
    </crater-results>
  ```

And put that into the jest test, and made it pass.

See https://github.com/concord-consortium/lara/blob/master/spec/libs/c_rater/api_wrapper_spec.rb#L30

attn: @dougmartin 