### PR TITLE
Fix "new Buffer(..." deprecation warning [#169504361]

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -4,4 +4,4 @@ if (!cRaterUsername || !cRaterPassword) {
   throw new Error("Missing C_RATER_USERNAME or C_RATER_PASSWORD environment variable!");
 }
 
-exports.authorizationValue = `Basic ${new Buffer(`${cRaterUsername}:${cRaterPassword}`).toString('base64')}`;
+exports.authorizationValue = `Basic ${Buffer.from(`${cRaterUsername}:${cRaterPassword}`).toString('base64')}`;


### PR DESCRIPTION
This started showing when the AWS Lambda functions were upgraded to Node 10 from Node 8 on staging.