### PR TITLE
Return CORS headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,3 +124,5 @@ exports.handler = async (event) => {
     }
   }
 };
+
+exports.headers = headers;

--- a/index.js
+++ b/index.js
@@ -8,6 +8,13 @@ const parseXML = util.promisify(parseString);
 
 const { authorizationValue, authorizationEnabled } = require("./auth");
 
+const headers = {
+  "Content-Type": "text/xml",
+  "Access-Control-Allow-Headers": "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS"
+};
+
 const getResponseResult = async (clientId, itemId, responseArray) => {
   const response = responseArray[0];
   const responseId = response.$ ? response.$.id : null;
@@ -100,7 +107,7 @@ exports.handler = async (event) => {
 
     return {
       statusCode: 200,
-      headers: {"Content-Type": "text/xml"},
+      headers,
       body: builder.buildObject(result)
     }
   }
@@ -112,7 +119,7 @@ exports.handler = async (event) => {
     innerResult.error = {$: {code: errorStatusCode}, _: e.toString()};
     return {
       statusCode: errorStatusCode,
-      headers: {"Content-Type": "text/xml"},
+      headers,
       body: builder.buildObject(result)
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "question-rater-lambda",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "question-rater-lambda",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^6.2.0",

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,3 +1,5 @@
+const {headers} = require("../index");
+
 const ignoreWhiteSpace = (string) => string.replace(/[\r|\n|\t\s]?/gm, "");
 
 const assertXmlMatch = (actual, expected) => {
@@ -7,7 +9,7 @@ const assertXmlMatch = (actual, expected) => {
 const errorResult = (error, includeClientId) => {
   return {
     statusCode: 400,
-    headers: {"Content-Type": "text/xml"},
+    headers,
     body: `<crater-results>\n  <tracking id="12345"/>\n${includeClientId ? "  <client id=\"cc\"/>\n" : ""}  <error code="400">${error}</error>\n</crater-results>`
   }
 }


### PR DESCRIPTION
When we use PROXY integration in API Gateway, we have to specify headers in the lambda itself. 
See: https://github.com/concord-consortium/cloud-formation/pull/62